### PR TITLE
Fixed icon for element nightly

### DIFF
--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -198,6 +198,7 @@ ds-emulator.png desmume.png
 earth.png marble.png
 EasyTAG_icon.png easytag.png
 ekiga.png im-ekiga.png
+element-desktop-nightly.png element-desktop.png
 emacs.png deepin-emacs.png
 emacs.png emacs23.png
 emacs.png emacs24.png


### PR DESCRIPTION
Element nightly uses a separate copy of the same identical icon, so we should use a symlink for it.