### PR TITLE
add symlink for budgie control center

### DIFF
--- a/Moka/16x16/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/16x16/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/16x16@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/16x16@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/22x22/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/22x22/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/22x22@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/22x22@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/24x24/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/24x24/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/24x24@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/24x24@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/256x256/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/256x256/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/256x256@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/256x256@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/32x32/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/32x32/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/32x32@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/32x32@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/48x48/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/48x48/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/48x48@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/48x48@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/64x64/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/64x64/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/64x64@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/64x64@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/96x96/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/96x96/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/96x96@2x/apps/org.buddiesofbudgie.Settings.png
+++ b/Moka/96x96@2x/apps/org.buddiesofbudgie.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -672,6 +672,7 @@ preferences-system.png cs-cat-prefs.png
 preferences-system.png cs-general.png
 preferences-system.png gtk-preferences.png
 preferences-system.png org.gnome.Settings.png
+preferences-system.png org.buddiesofbudgie.Settings.png
 preferences-system.png org.xfce.settings.manager.png
 preferences-system.png system-settings.png
 preferences-system.png v4l2ucp.png


### PR DESCRIPTION
Budgie now ships a custom control center which replaces the gnome one. The icon should remain the same, though